### PR TITLE
[스프링]대시보드 출퇴근 기능 추가

### DIFF
--- a/src/main/java/com/kdt/controllers/DashboardController.java
+++ b/src/main/java/com/kdt/controllers/DashboardController.java
@@ -5,22 +5,30 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kdt.dto.AttendenceDTO;
+import com.kdt.services.AttendenceService;
+
 @RestController
 @RequestMapping("/api/dash")
 public class DashboardController {
 	
-	@PostMapping
-	public ResponseEntity<String> checkIn(@RequestPart("id")String id, @RequestPart("date") String date, @RequestPart("time")String time) throws Exception{
+	@Autowired
+	private AttendenceService AtdService;
+
+	
+	@PostMapping("/checkin")
+	public ResponseEntity<Integer> checkIn(@RequestPart("id")String id, @RequestPart("date") String date, @RequestPart("time")String time) throws Exception{
 		System.out.println(id+" / "+date+" / "+time);
-//		String decodedTime = URLDecoder.decode(checkInTime,"utf8");
-//		System.out.println(decodedTime);
 		         
          String combinedString = date + " " + time;
          
@@ -32,8 +40,47 @@ public class DashboardController {
          Timestamp timestamp = new Timestamp(formeddate.getTime());
          
          System.out.println("타임스탬프: " + timestamp);
+         
+         AttendenceDTO dto = new AttendenceDTO();
+         
+         dto.setId(id);
+         dto.setWorkstart(timestamp);
+         
+         int result = AtdService.insertCheckIn(dto);
 		
-		return ResponseEntity.ok().build();
+		return ResponseEntity.ok(result);
 	}
+	
+	@PostMapping("/checkout")
+	public ResponseEntity<Integer> checkout(@RequestPart("id")String id, @RequestPart("date") String date, @RequestPart("time")String time) throws Exception{
+		System.out.println(id+" / "+date+" / "+time);
+		         
+         String combinedString = date + " " + time;
+         
+         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy. MM. d. HH:mm:ss");
+         Date formeddate = dateFormat.parse(combinedString);
+         
+         
+         Timestamp timestamp = new Timestamp(formeddate.getTime());
+         
+         System.out.println("타임스탬프: " + timestamp);
+         
+         AttendenceDTO dto = new AttendenceDTO();
+         
+         dto.setId(id);
+         dto.setWorkend(timestamp);
+         
+		return ResponseEntity.ok(1);
+	}
+	
+	@GetMapping("/workstart/{id}")
+	public ResponseEntity<AttendenceDTO> workstart(@PathVariable String id){
+		System.out.println(id);
+		AttendenceDTO dto = AtdService.selectWorkStart(id);		
+		
+		return ResponseEntity.ok(dto);
+	}
+	
+	
 
 }

--- a/src/main/java/com/kdt/controllers/DashboardController.java
+++ b/src/main/java/com/kdt/controllers/DashboardController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -51,7 +52,7 @@ public class DashboardController {
 		return ResponseEntity.ok(result);
 	}
 	
-	@PostMapping("/checkout")
+	@PutMapping("/checkout")
 	public ResponseEntity<Integer> checkout(@RequestPart("id")String id, @RequestPart("date") String date, @RequestPart("time")String time) throws Exception{
 		System.out.println(id+" / "+date+" / "+time);
 		         
@@ -69,8 +70,9 @@ public class DashboardController {
          
          dto.setId(id);
          dto.setWorkend(timestamp);
+         int result = AtdService.updateWorkEnd(dto);
          
-		return ResponseEntity.ok(1);
+		return ResponseEntity.ok(result);
 	}
 	
 	@GetMapping("/workstart/{id}")

--- a/src/main/java/com/kdt/dao/AttendenceDAO.java
+++ b/src/main/java/com/kdt/dao/AttendenceDAO.java
@@ -19,5 +19,9 @@ public class AttendenceDAO {
 	public AttendenceDTO selectWorkStart(String id) {
 		return db.selectOne("Attendence.selectWorkStart",id);
 	}
+	
+	public int updateWorkEnd(AttendenceDTO dto) {
+		return db.update("Attendence.updateWorkEnd",dto);
+	}
 
 }

--- a/src/main/java/com/kdt/dao/AttendenceDAO.java
+++ b/src/main/java/com/kdt/dao/AttendenceDAO.java
@@ -4,12 +4,20 @@ import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import com.kdt.dto.AttendenceDTO;
+
 @Repository
 public class AttendenceDAO {
 	
 	@Autowired
 	private SqlSession db;
 	
+	public int insertCheckIn(AttendenceDTO dto) {
+		return db.insert("Attendence.insertCheckIn", dto);
+	}
 	
+	public AttendenceDTO selectWorkStart(String id) {
+		return db.selectOne("Attendence.selectWorkStart",id);
+	}
 
 }

--- a/src/main/java/com/kdt/services/AttendenceService.java
+++ b/src/main/java/com/kdt/services/AttendenceService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.kdt.dao.AttendenceDAO;
+import com.kdt.dto.AttendenceDTO;
 
 @Service
 public class AttendenceService {
@@ -11,6 +12,12 @@ public class AttendenceService {
 	@Autowired
 	private AttendenceDAO dao;
 	
+	public int insertCheckIn(AttendenceDTO dto) {
+		return dao.insertCheckIn(dto);
+	}
 	
+	public AttendenceDTO selectWorkStart(String id) {
+		return dao.selectWorkStart(id);
+	}
 
 }

--- a/src/main/java/com/kdt/services/AttendenceService.java
+++ b/src/main/java/com/kdt/services/AttendenceService.java
@@ -19,5 +19,9 @@ public class AttendenceService {
 	public AttendenceDTO selectWorkStart(String id) {
 		return dao.selectWorkStart(id);
 	}
+	
+	public int updateWorkEnd(AttendenceDTO dto) {
+		return dao.updateWorkEnd(dto);
+	}
 
 }

--- a/src/main/resources/mappers/attendence.xml
+++ b/src/main/resources/mappers/attendence.xml
@@ -10,5 +10,8 @@
 	<select id="selectWorkStart" resultType="com.kdt.dto.AttendenceDTO">
 		SELECT * FROM attendence WHERE DATE(workstart) = CURDATE() and id = #{value};
 	</select>
+	<update id="updateWorkEnd">
+		update attendence set workend = #{workend} where id = #{id}
+	</update>
 
 </mapper>

--- a/src/main/resources/mappers/attendence.xml
+++ b/src/main/resources/mappers/attendence.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="Attendence">
+	<insert id="insertCheckIn">
+		insert into attendence values(0, #{id}, #{workstart}, null, null)
+	</insert>
+	
+	<select id="selectWorkStart" resultType="com.kdt.dto.AttendenceDTO">
+		SELECT * FROM attendence WHERE DATE(workstart) = CURDATE() and id = #{value};
+	</select>
+
+</mapper>


### PR DESCRIPTION
대시보드 페이지에서 출근 데이터를 기록한 후 새로고침을 해도 데이터가 사라지지 않도록 수정했습니다.
대시보드 페이지에서 퇴근 데이터를 기록하면 기존의 출근데이터에 업데이트 되도록 구현했습니다.
이에따라 대시보드 컨트롤러와 mapper, dao, service를 수정했습니다.